### PR TITLE
Bump django from 5.1.1 to 5.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Brotli==1.1.0
 click==8.1.7
 crispy-bootstrap5==2024.10
 dj-database-url==2.3.0
-Django==5.1.1
+Django==5.1.4
 django-bootstrap5==24.3
 django-crispy-forms==2.3
 django-extensions==3.2.3


### PR DESCRIPTION
### Vulnerabilities Fixed

- **SQL Injection**:
  Direct usage of the `django.db.models.fields.json.HasKey` lookup, when an Oracle database is used, is subject to SQL injection if untrusted data is used as an lhs value.
(*Note: Applications that use the `jsonfield.has_key` lookup via __ are unaffected.*)

- **Denial-of-Service (DoS)**:
  The `strip_tags()` method and `striptags template filter` are subject to a potential denial-of-service attack via certain inputs containing large sequences of nested incomplete HTML entities.
